### PR TITLE
Replace LJH3 header with YAML

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -6,3 +6,4 @@ DataStructures
 ZMQ
 Distributions
 JSON
+YAML

--- a/test/ljh3.jl
+++ b/test/ljh3.jl
@@ -4,7 +4,7 @@ using Base.Test
 
 @testset "ljh3" begin
 
-header_extra = OrderedDict(["a"=>"b","c"=>"d","e"=>Dict("ea"=>"eb")])
+header_extra = Dict(["a"=>"b","c"=>"d","e"=>Dict("ea"=>"eb")])
 fname = tempname()
 fw = LJH.create3(fname, 9.6e-6, header_extra)
 


### PR DESCRIPTION
Galen, I'm not sure that I actually want you to pull this and change our format to YAML, but here is an implementation that works, for us to consider.

* YAML advantage: already and automatically includes the newline after the end-of-YAML marker `...\n`, which you had trouble getting to work in JSON.
* YAML advantage: slightly more readable, no quotation marks in the text.
* YAML disadvantage: doesn't support the `OrderedDict` or automatic writing of YAML. So for example, if the value (in a key-value pair) is itself a dictionary, YAML doesn't store it as such.