### PR TITLE
Ljh3 header has a required newline after JSON

### DIFF
--- a/docs/src/ljh.md
+++ b/docs/src/ljh.md
@@ -180,9 +180,9 @@ change_writing_status
 
 ## LJH3
 
-LJH3 is a new version of LJH intended to allow the use of variable length records for analyses such as multi-pulse fitting or single pulse fitting. LJH3 files have a JSON header containing at least 3 keys: "sampleperiod", "File Format"="LJH3", and "File Format Version". It should contains additional keys with information about the readout, but these are not currently required.
+LJH3 is a new version of LJH intended to allow the use of variable length records for analyses such as multi-pulse fitting or single pulse fitting. LJH3 files have a JSON header containing at least 3 keys: "sampleperiod", "File Format"="LJH3", and "File Format Version". It should contain additional keys with information about the readout, but these are not currently required. The JSON is followed by a single newline "\n".
 
-After the header, records are written as flat binary data. Each record consists of a `Int32` record length, a `Int32` offset into the record pointing to the first rising sample as determined by the trigger algorithm, a `Int64` samplecount of the first sample in the record, and an `Int64` posix timestamp in units of microseconds since the epoch. The samplecount is provided by the readout system, and may have arbitrary offset, such that comparisons across different LJH3 files from the same readout system are not meaningful.
+Immediatley following the header, records are written as flat binary data. Each record consists of a `Int32` record length, a `Int32` offset into the record pointing to the first rising sample as determined by the trigger algorithm, a `Int64` samplecount of the first sample in the record, and an `Int64` posix timestamp in units of microseconds since the epoch. The samplecount is provided by the readout system, and may have arbitrary offset, such that comparisons across different LJH3 files from the same readout system are not meaningful.
 
 
 ```@docs

--- a/src/ljh3.jl
+++ b/src/ljh3.jl
@@ -20,6 +20,7 @@ function LJH3File(io::IO; shouldseekstart=true)
     shouldseekstart && seekstart(io)
     header = JSON.parse(io, dicttype=OrderedDict)
     sampleperiod = header["sampleperiod"]
+    @assert read(io, Char) == '\n'
     @assert header["File Format"]=="LJH3"
     @assert header["File Format Version"] == "3.0.0"
     LJH3File(io,Int[position(io)],sampleperiod, header)
@@ -64,19 +65,21 @@ function Base.write(ljh::LJH3File, trace::Vector{UInt16},first_rising_sample, sa
 end
 """    create3(filename::AbstractString, sampleperiod, header_extra = Dict();version="3.0.0")
 Return an `LJH3File` ready for writing with `write`. The header will contain "sampleperiod",
-"File Format", "File Format Version" and any items in `header_extra`. The three listed items
-will overwrite items in `header_extra`.
+"File Format", "File Format Version" and any items in `header_extra`. Items in `header_extra`
+will overwrite the header items passed as arguments, and you can make an invalid LJH3 file
+this way. You are advised to avoid creating invalid LJH3 files.
 """
 function create3(filename::AbstractString, sampleperiod, header_extra = Dict();version="3.0.0")
     io = open(filename,"w+")
     header = OrderedDict{String,Any}()
-    for (k,v) in header_extra
-        header[k]=v
-    end
     header["File Format"] = "LJH3"
     header["File Format Version"] = version
     header["sampleperiod"]=sampleperiod
+    for (k,v) in header_extra
+        header[k]=v
+    end
     JSON.print(io, header, 4) # last argument uses pretty printing
+    print(io,"\n")
     LJH3File(io)
 end
 function seekto(ljh::LJH3File, i::Int)


### PR DESCRIPTION
@joefowler Alternate LJH3 header approach with required trailing newline.