### PR TITLE
Ljh3 universal api

### DIFF
--- a/docs/src/ljh.md
+++ b/docs/src/ljh.md
@@ -185,7 +185,7 @@ LJH3 is a new version of LJH intended to allow the use of variable length record
 Immediatley following the header, records are written as flat binary data. Each record consists of a `Int32` record length, a `Int32` offset into the record pointing to the first rising sample as determined by the trigger algorithm, a `Int64` frame1index of the first sample in the record, and an `Int64` posix timestamp in units of microseconds since the epoch for the first sample in the record. The frame1index is provided by the readout system, and may have arbitrary offset, such that comparisons across different LJH3 files from the same readout system are not meaningful.
 
 ## LJH Records and LJH3 Records API
-Both `LJHRecord` from version 2 files, and `LJH3Record` from version 3 files have a shared API. The API consists of the functions `frameperiod`, `frame1index`, `first_rising_sample`, `data`, and `timestamp_usec`. 
+Both `LJHRecord` from version 2 files, and `LJH3Record` from version 3 files have a shared API. The API consists of the functions `frameperiod`, `frame1index`, `first_rising_sample`, `data`, and `timestamp_usec`. For TDM data different rows within the same frame have different timing, which is not reflected in `frame1index`, use `rowcount` instead when sub-frame timing information is required. `rowcount = frame1index*num_rows+row`.
 
 
 ```@docs

--- a/docs/src/ljh.md
+++ b/docs/src/ljh.md
@@ -184,6 +184,9 @@ LJH3 is a new version of LJH intended to allow the use of variable length record
 
 Immediatley following the header, records are written as flat binary data. Each record consists of a `Int32` record length, a `Int32` offset into the record pointing to the first rising sample as determined by the trigger algorithm, a `Int64` frame1index of the first sample in the record, and an `Int64` posix timestamp in units of microseconds since the epoch for the first sample in the record. The frame1index is provided by the readout system, and may have arbitrary offset, such that comparisons across different LJH3 files from the same readout system are not meaningful.
 
+## LJH Records and LJH3 Records API
+Both `LJHRecord` from version 2 files, and `LJH3Record` from version 3 files have a shared API. The API consists of the functions `frameperiod`, `frame1index`, `first_rising_sample`, `data`, and `timestamp_usec`. Be warned that `frame1index` on `LJHRecord` return a "rowcount" and not a framecount, and thus the interpretation is not always identical.
+
 
 ```@docs
 LJH3File

--- a/docs/src/ljh.md
+++ b/docs/src/ljh.md
@@ -185,7 +185,7 @@ LJH3 is a new version of LJH intended to allow the use of variable length record
 Immediatley following the header, records are written as flat binary data. Each record consists of a `Int32` record length, a `Int32` offset into the record pointing to the first rising sample as determined by the trigger algorithm, a `Int64` frame1index of the first sample in the record, and an `Int64` posix timestamp in units of microseconds since the epoch for the first sample in the record. The frame1index is provided by the readout system, and may have arbitrary offset, such that comparisons across different LJH3 files from the same readout system are not meaningful.
 
 ## LJH Records and LJH3 Records API
-Both `LJHRecord` from version 2 files, and `LJH3Record` from version 3 files have a shared API. The API consists of the functions `frameperiod`, `frame1index`, `first_rising_sample`, `data`, and `timestamp_usec`. Be warned that `frame1index` on `LJHRecord` return a "rowcount" and not a framecount, and thus the interpretation is not always identical.
+Both `LJHRecord` from version 2 files, and `LJH3Record` from version 3 files have a shared API. The API consists of the functions `frameperiod`, `frame1index`, `first_rising_sample`, `data`, and `timestamp_usec`. 
 
 
 ```@docs

--- a/docs/src/ljh.md
+++ b/docs/src/ljh.md
@@ -1,94 +1,122 @@
 # LJH
-LJH is a module for reading and writing LJH files. It supports versions 2.1 and
-2.2 of LJH, and provides a way to handle multiple LJH files. It is a submodule of Pope so you will want to `using Pope.LJH` or `using Pope: LJH`.
+LJH is a module for reading and writing LJH files. It supports versions 2.1, 2.2 and 3.0 of LJH with a shared API for reading these files. LJH3 supports variable length records, and makes no assumptions about the readout system. LJH22 has Time Division Multiplexing assumptions built in, and support fixed length records only. It also provides a way to handle multiple LJH files. It is a submodule of Pope so you will want to `using Pope.LJH` or `using Pope: LJH`.
 
 ```@contents
 Depth = 2
 ```
 
 ```@meta
-DocTestSetup = quote using Pope.LJH end
+DocTestSetup = quote
+using Pope.LJH
+end
 ```
-## Writing LJH Files
-```jldoctest ljh
-julia> dt = 9.6e-6; npre = 200; nsamp = 1000; nrow = 30; rowcount = 1; timestamp=2;
 
-julia> ljh = LJH.create("ljh.ljh", dt, npre, nsamp; version="2.2.0", number_of_rows=nrow)
-LJHFile ljh.ljh
+## Writing LJH3 Files
+```jldoctest ljh
+julia> frameperiod = 9.6e-6;
+
+julia> ljh = LJH.create3("ljh_chan_1.ljh", frameperiod)
+Pope.LJH.LJH3File{9.6e-6}(IOStream(<file ljh_chan_1.ljh>), [93], DataStructures.OrderedDict{String,Any}("File Format"=>"LJH3","File Format Version"=>"3.0.0","frameperiod"=>9.6e-6))
+
+julia> write(ljh, Vector{UInt16}(1:100), 10, 1000, 2000);
+
+julia> write(ljh, Vector{UInt16}(1:1000), 20, 2000, 3000);
+
+julia> close(ljh);
+```
+
+```@docs
+create3
+write(ljh::LJH3File, trace::Vector{UInt16},first_rising_sample, samplecount::Int64, timestamp_usec::Int64)
+```
+
+## Writing LJH2 Files
+```jldoctest ljh
+julia> frameperiod = 9.6e-6; npre = 200; nsamp = 1000; nrow = 30; rowcount = 1; timestamp=2;
+
+julia> ljh2 = LJH.create("ljh2_chan1.ljh", dt, npre, nsamp; version="2.2.0", num_rows=nrow)
+LJHFile ljh2_chan1.ljh
 0 records
 record_nsamlpes 1000, pretrig_nsamples 200.
 Channel 1, row 0, column 0, frametime 9.6e-6 s.
 
 
-julia> write(ljh, Vector{UInt16}(1:nsamp), rowcount, timestamp)
-2016
+julia> write(ljh2, Vector{UInt16}(1:nsamp), rowcount, timestamp);
 
-julia> write(ljh, Vector{UInt16}(1:nsamp), rowcount, timestamp)
-2016
+julia> write(ljh2, Vector{UInt16}(1:nsamp), rowcount, timestamp);
 
-julia> close(ljh)
+julia> close(ljh2);
+```
+
+```@docs
+create
+write(ljh::LJHFile{LJH_22}, trace::Vector{UInt16}, rowcount::Int64, timestamp_usec::Int64)
 ```
 
 ## Reading LJH Files
 ```jldoctest ljh
-julia> ljhr = LJH.LJHFile(LJH.filename(ljh))
-LJHFile ljh.ljh
-2 records
-record_nsamlpes 1000, pretrig_nsamples 200.
-Channel 1, row 0, column 0, frametime 9.6e-6 s.
-
+julia> ljhr = ljhopen(LJH.filename(ljh))
+Pope.LJH.LJH3File{9.6e-6}(IOStream(<file ljh_chan_1.ljh>), [93], DataStructures.OrderedDict{String,Any}("File Format"=>"LJH3","File Format Version"=>"3.0.0","frameperiod"=>9.6e-6))
 
 julia> record = ljhr[1];
 
 julia> LJH.data(record)' # transpose for less verbose output
-1×1000 RowVector{UInt16,Array{UInt16,1}}:
- 0x0001  0x0002  0x0003  0x0004  0x0005  …  0x03e5  0x03e6  0x03e7  0x03e8
+1×100 RowVector{UInt16,Array{UInt16,1}}:
+ 0x0001  0x0002  0x0003  0x0004  0x0005  0x0006  …  0x0060  0x0061  0x0062  0x0063  0x0064
 
-julia> LJH.rowcount(record)
-1
+julia> LJH.frame1index(record)
+1000
+
+julia> LJH.frameperiod(record)
+9.6e-6
+
+julia> LJH.first_rising_sample(record)
+10
 
 julia> LJH.timestamp_usec(record)
-2
+2000
 
 julia> records = collect(ljhr)
 2-element Array{Any,1}:
- Pope.LJH.LJHRecord(UInt16[0x0001, 0x0002, 0x0003, 0x0004, 0x0005, 0x0006, 0x0007, 0x0008, 0x0009, 0x000a  …  0x03df, 0x03e0, 0x03e1, 0x03e2, 0x03e3, 0x03e4, 0x03e5, 0x03e6, 0x03e7, 0x03e8], 1, 2)
- Pope.LJH.LJHRecord(UInt16[0x0001, 0x0002, 0x0003, 0x0004, 0x0005, 0x0006, 0x0007, 0x0008, 0x0009, 0x000a  …  0x03df, 0x03e0, 0x03e1, 0x03e2, 0x03e3, 0x03e4, 0x03e5, 0x03e6, 0x03e7, 0x03e8], 1, 2)
 
-julia> LJH.rowcount.(records)
+ Pope.LJH.LJH3Record{9.6e-6}(UInt16[0x0001, 0x0002, 0x0003, 0x0004, 0x0005, 0x0006, 0x0007, 0x0008, 0x0009, 0x000a  …  0x005b, 0x005c, 0x005d, 0x005e, 0x005f, 0x0060, 0x0061, 0x0062, 0x0063, 0x0064], 10, 1000, 2000)
+ Pope.LJH.LJH3Record{9.6e-6}(UInt16[0x0001, 0x0002, 0x0003, 0x0004, 0x0005, 0x0006, 0x0007, 0x0008, 0x0009, 0x000a  …  0x03df, 0x03e0, 0x03e1, 0x03e2, 0x03e3, 0x03e4, 0x03e5, 0x03e6, 0x03e7, 0x03e8], 20, 2000, 3000)
+
+julia> LJH.length.(records)
 2-element Array{Int64,1}:
- 1
- 1
-
-julia> records2 = collect(ljhr[1:1])
-1-element Array{Any,1}:
- Pope.LJH.LJHRecord(UInt16[0x0001, 0x0002, 0x0003, 0x0004, 0x0005, 0x0006, 0x0007, 0x0008, 0x0009, 0x000a  …  0x03df, 0x03e0, 0x03e1, 0x03e2, 0x03e3, 0x03e4, 0x03e5, 0x03e6, 0x03e7, 0x03e8], 1, 2)
-
-julia> data, rowcount, timestamp_usec = LJH.get_data_rowcount_timestamp(ljhr)
-(UInt16[0x0001 0x0001; 0x0002 0x0002; … ; 0x03e7 0x03e7; 0x03e8 0x03e8], [1, 1], [2, 2])
+  100
+ 1000
 
 julia> close(ljhr)
+```
 
+```@docs
+ljhopen
 ```
 
 ### Reading LJH files when data may or may not be available
 ```jldoctest ljh
-julia> ljhr = LJH.LJHFile(LJH.filename(ljh));
+julia> ljhr = ljhopen(LJH.filename(ljh))
+Pope.LJH.LJH3File{9.6e-6}(IOStream(<file ljh_chan_1.ljh>), [93], DataStructures.OrderedDict{String,Any}("File Format"=>"LJH3","File Format Version"=>"3.0.0","frameperiod"=>9.6e-6))
 
 julia> LJH.tryread(ljhr)
-Nullable{Pope.LJH.LJHRecord}(Pope.LJH.LJHRecord(UInt16[0x0001, 0x0002, 0x0003, 0x0004, 0x0005, 0x0006, 0x0007, 0x0008, 0x0009, 0x000a  …  0x03df, 0x03e0, 0x03e1, 0x03e2, 0x03e3, 0x03e4, 0x03e5, 0x03e6, 0x03e7, 0x03e8], 1, 2))
+Nullable{Pope.LJH.LJH3Record{9.6e-6}}(Pope.LJH.LJH3Record{9.6e-6}(UInt16[0x0001, 0x0002, 0x0003, 0x0004, 0x0005, 0x0006, 0x0007, 0x0008, 0x0009, 0x000a  …  0x005b, 0x005c, 0x005d, 0x005e, 0x005f, 0x0060, 0x0061, 0x0062, 0x0063, 0x0064], 10, 1000, 2000))
 
 julia> LJH.tryread(ljhr)
-Nullable{Pope.LJH.LJHRecord}(Pope.LJH.LJHRecord(UInt16[0x0001, 0x0002, 0x0003, 0x0004, 0x0005, 0x0006, 0x0007, 0x0008, 0x0009, 0x000a  …  0x03df, 0x03e0, 0x03e1, 0x03e2, 0x03e3, 0x03e4, 0x03e5, 0x03e6, 0x03e7, 0x03e8], 1, 2))
+Nullable{Pope.LJH.LJH3Record{9.6e-6}}(Pope.LJH.LJH3Record{9.6e-6}(UInt16[0x0001, 0x0002, 0x0003, 0x0004, 0x0005, 0x0006, 0x0007, 0x0008, 0x0009, 0x000a  …  0x03df, 0x03e0, 0x03e1, 0x03e2, 0x03e3, 0x03e4, 0x03e5, 0x03e6, 0x03e7, 0x03e8], 20, 2000, 3000))
 
 julia> LJH.tryread(ljhr)
-Nullable{Pope.LJH.LJHRecord}()
+Nullable{Pope.LJH.LJH3Record{9.6e-6}}()
 
 julia> close(ljhr)
 
 ```
 
-### Reading many LJH files simultaneously
+```@docs
+tryread
+```
+
+### Reading many LJH2 files simultaneously
 ```jldoctest ljh
 julia> names = [c*".ljh" for c in ["a","b","c"]]
 3-element Array{String,1}:
@@ -184,16 +212,12 @@ LJH3 is a new version of LJH intended to allow the use of variable length record
 
 Immediatley following the header, records are written as flat binary data. Each record consists of a `Int32` record length, a `Int32` offset into the record pointing to the first rising sample as determined by the trigger algorithm, a `Int64` frame1index of the first sample in the record, and an `Int64` posix timestamp in units of microseconds since the epoch for the first sample in the record. The frame1index is provided by the readout system, and may have arbitrary offset, such that comparisons across different LJH3 files from the same readout system are not meaningful.
 
+### LJH2
+
+The specification is available on the internal wiki http://doc/qsp/computing:ljh_file_format
+
 ## LJH Records and LJH3 Records API
 Both `LJHRecord` from version 2 files, and `LJH3Record` from version 3 files have a shared API. The API consists of the functions `frameperiod`, `frame1index`, `first_rising_sample`, `data`, and `timestamp_usec`. For TDM data different rows within the same frame have different timing, which is not reflected in `frame1index`, use `rowcount` instead when sub-frame timing information is required. `rowcount = frame1index*num_rows+row`.
-
-
-```@docs
-LJH3File
-LJH3Record
-create3
-write(ljh::LJH3File, trace::Vector{UInt16},first_rising_sample, samplecount::Int64, timestamp_usec::Int64)
-```
 
 ## Autodocs LJH
 ```@autodocs

--- a/src/LJH.jl
+++ b/src/LJH.jl
@@ -45,6 +45,11 @@ end
 data(r::LJHRecord) = r.data
 rowcount(r::LJHRecord) = r.rowcount
 timestamp_usec(r::LJHRecord) = r.timestamp_usec
+frameperiod(r::LJHRecord{FrameTime, PretrigNSamples}) where {FrameTime, PretrigNSamples} = FrameTime
+frame1index(r::LJHRecord{FrameTime, PretrigNSamples}) where {FrameTime, PretrigNSamples} = rowcount(r)
+first_rising_sample(r::LJHRecord{FrameTime, PretrigNSamples}) where {FrameTime, PretrigNSamples} = PretrigNSamples
+
+
 Base.length(r::LJHRecord) = length(r.data)
 import Base: ==
 ==(a::LJHRecord, b::LJHRecord) = a.data==b.data && a.rowcount == b.rowcount && a.timestamp_usec == b.timestamp_usec

--- a/src/LJH.jl
+++ b/src/LJH.jl
@@ -85,8 +85,8 @@ LJHFile(f::LJHFile) = f
 
 "record_nbytes(f::LJHFile)
     Return number of bytes per record in LJH file, based on version number"
-record_nbytes(f::LJHFile{LJH_21,T}) where T = 6+2*f.record_nsamples
-record_nbytes(f::LJHFile{LJH_22,T}) where T = 16+2*f.record_nsamples
+record_nbytes(f::LJHFile{LJH_21}) = 6+2*f.record_nsamples
+record_nbytes(f::LJHFile{LJH_22}) = 16+2*f.record_nsamples
 
 "    ljh_number_of_records(f::LJHFile)
 Return the number of complete records currently available to read from `f`."
@@ -114,12 +114,12 @@ function Base.getindex(f::LJHFile,index::Int)
     seekto(f, index)
     pop!(f)
 end
-function Base.pop!{T}(f::LJHFile{LJH_21,T})
+function Base.pop!(f::LJHFile{LJH_21})
     rowcount, timestamp_usec =  record_row_count_v21(read(f.io, UInt8, 6), f.num_rows, f.row, f.frametime)
     data = read(f.io, UInt16, f.record_nsamples)
     LJHRecord(data, rowcount, timestamp_usec)
 end
-function Base.pop!{T}(f::LJHFile{LJH_22,T})
+function Base.pop!(f::LJHFile{LJH_22})
     rowcount = read(f.io, Int64)
     timestamp_usec = read(f.io, Int64)
     data = read(f.io, UInt16, f.record_nsamples)
@@ -139,6 +139,7 @@ channel(f::LJHFile) = f.channum
 row(f::LJHFile) = f.row
 column(f::LJHFile) = f.column
 frametime(f::LJHFile) = f.frametime
+frameperiod(f::LJHFile) = frametime(f)
 function Base.show(io::IO, g::LJHFile)
     print(io, "LJHFile $(filename(g))\n")
     print(io, "$(length(g)) records\n")
@@ -445,29 +446,29 @@ Discrimination level (%%): 1.000000
 flush(io)
 end
 
-"    write{T}(ljh::LJHFile{LJH_22,T},traces::Array{UInt16,2}, rowcounts::Vector{Int64}, times::Vector{Int64})"
-function Base.write{T}(ljh::LJHFile{LJH_22,T},traces::Array{UInt16,2}, rowcounts::Vector{Int64}, times::Vector{Int64})
+"    write(ljh::LJHFile{LJH_22},traces::Array{UInt16,2}, rowcounts::Vector{Int64}, times::Vector{Int64})"
+function Base.write(ljh::LJHFile{LJH_22},traces::Array{UInt16,2}, rowcounts::Vector{Int64}, times::Vector{Int64})
     for j = 1:length(times)
         write(ljh, traces[:,j], rowcounts[j], times[j])
     end
 end
-"    write{T}(ljh::LJHFile{LJH_22,T}, trace::Vector{UInt16}, rowcount::Int64, time::Int64)"
-function Base.write{T}(ljh::LJHFile{LJH_22,T}, trace::Vector{UInt16}, rowcount::Int64, timestamp_usec::Int64)
+"    write(ljh::LJHFile{LJH_22}, trace::Vector{UInt16}, rowcount::Int64, time::Int64)"
+function Base.write(ljh::LJHFile{LJH_22}, trace::Vector{UInt16}, rowcount::Int64, timestamp_usec::Int64)
     write(ljh.io, rowcount, timestamp_usec, trace)
 end
-"    write{T}(ljh::LJHFile{LJH_22,T}, record::LJHRecord)"
-function Base.write{T}(ljh::LJHFile{LJH_22,T}, record::LJHRecord)
+"    write(ljh::LJHFile{LJH_22}, record::LJHRecord)"
+function Base.write(ljh::LJHFile{LJH_22}, record::LJHRecord)
   write(ljh, record.data, record.rowcount, record.timestamp_usec)
 end
 
-"    write{T}(ljh::LJHFile{LJH_21,T},traces::Array{UInt16,2}, rowcounts::Vector{Int64})"
-function Base.write{T}(ljh::LJHFile{LJH_21,T},traces::Array{UInt16,2}, rowcounts::Vector{Int64})
+"    write(ljh::LJHFile{LJH_21},traces::Array{UInt16,2}, rowcounts::Vector{Int64})"
+function Base.write(ljh::LJHFile{LJH_21},traces::Array{UInt16,2}, rowcounts::Vector{Int64})
     for j = 1:length(rowcounts)
         write(ljh, traces[:,j], rowcounts[j])
     end
 end
-"    write{T}(ljh::LJHFile{LJH_21,T}, trace::Vector{UInt16}, rowcount::Int64)"
-function Base.write{T}(ljh::LJHFile{LJH_21,T}, trace::Vector{UInt16}, rowcount::Int64)
+"    write(ljh::LJHFile{LJH_21}, trace::Vector{UInt16}, rowcount::Int64)"
+function Base.write(ljh::LJHFile{LJH_21}, trace::Vector{UInt16}, rowcount::Int64)
   lsync_us = 1e6*ljh.frametime/ljh.num_rows
   timestamp_us = round(Int, rowcount*lsync_us)
   timestamp_ms = Int32(div(timestamp_us, 1000))
@@ -478,8 +479,8 @@ function Base.write{T}(ljh::LJHFile{LJH_21,T}, trace::Vector{UInt16}, rowcount::
   write(ljh.io, timestamp_ms)
   write(ljh.io, trace)
 end
-"    Base.write{T}(ljh::LJHFile{LJH_21,T}, record::LJHRecord)"
-function Base.write{T}(ljh::LJHFile{LJH_21,T}, record::LJHRecord)
+"    Base.write(ljh::LJHFile{LJH_21}, record::LJHRecord)"
+function Base.write(ljh::LJHFile{LJH_21}, record::LJHRecord)
   write(ljh, record.data, record.rowcount)
 end
 

--- a/src/Pope.jl
+++ b/src/Pope.jl
@@ -177,8 +177,8 @@ Where `a` is an analyzer, and `ljh` is a pulse record souce. Throw an error if i
 Return value is not used."
 function check_compatability(a::MassCompatibleAnalysisFeb2017, ljh::LJH.LJHFile)
   ljh.record_nsamples == a.nsamples || error("Channel $(ljh.channum) has $(ljh.record_nsamples) samples, anlyzer has $(a.nsamples).")
-  ljh.pretrig_nsamples == a.npresamples || error("Channel $(ljh.channum) has $(ljh.pretrig_nsamples) pretrigger samples, anlyzer has $(a.npresamples).")
-  ljh.frametime == a.frametime || error("Channel $(ljh.channum) has $(ljh.frametime) frametime, anlyzer has $(a.frametime).")
+  LJH.pretrig_nsamples(ljh) == a.npresamples || error("Channel $(ljh.channum) has $(LJH.pretrig_nsamples(ljh)) pretrigger samples, anlyzer has $(a.npresamples).")
+  LJH.frametime(ljh) == a.frametime || error("Channel $(ljh.channum) has $(LJH.pretrig_nsamples(frametime)) frametime, anlyzer has $(a.frametime).")
 end
 function (a::MassCompatibleAnalysisFeb2017)(record::LJH.LJHRecord)
   summary = summarize(record.data, a.npresamples,a.nsamples, a.peak_index, a.frametime)

--- a/src/basis_apply.jl
+++ b/src/basis_apply.jl
@@ -39,17 +39,10 @@ struct BasisAnalyzer
     basis::Array{Float32,2} # size (nbasis,nsamples)
 end
 check_compatability(a::BasisAnalyzer, ljh) = nothing
-function (a::BasisAnalyzer)(record::LJH.LJHRecord)
-  reduced = a.basis*record.data
+function (a::BasisAnalyzer)(record::Union{LJH.LJHRecord, LJH.LJH3Record})
+  reduced = a.basis*LJH.data(record)
   data_subspace = a.basis'*reduced
-  residual_std = std(data_subspace-record.data)
-  BasisDataProduct(reduced, residual_std, LJH.rowcount(record),
-    LJH.timestamp_usec(record), 0, length(record))
-end
-function (a::BasisAnalyzer)(record::LJH.LJH3Record)
-  reduced = a.basis*record.data
-  data_subspace = a.basis'*reduced
-  residual_std = std(data_subspace-record.data)
+  residual_std = std(data_subspace-LJH.data(record))
   BasisDataProduct(reduced, residual_std, LJH.frame1index(record),
     LJH.timestamp_usec(record), LJH.first_rising_sample(record), length(record))
 end

--- a/test/basis_apply.jl
+++ b/test/basis_apply.jl
@@ -20,8 +20,9 @@ using ReferenceMicrocalFiles
 end
 
 @testset "BasisAnalyzer" begin
-    FrameTime, PretrigNSamples = 9.6e-6, 100
-    r = LJH.LJHRecord{FrameTime, PretrigNSamples}(1:1000,10,20)
+    FrameTime, PretrigNSamples, NRow, row = 9.6e-6, 100, 30, 1
+    # rowcount of LJH2 files = framecount*NRow+row, framecount=frame1index
+    r = LJH.LJHRecord{FrameTime, PretrigNSamples, NRow}(1:1000,10*NRow+row,20)
     r3 = LJH.LJH3Record{FrameTime}(1:1000,PretrigNSamples,10,20)
     analyzer = Pope.BasisAnalyzer(rand(6,1000))
     dp = analyzer(r)
@@ -69,7 +70,7 @@ end
     h5r = h5open(h5.filename,"r")
     @test (nbases,length(ljh)) == size(h5r["$(LJH.channel(ljh))/reduced"])
     @test all(LJH.record_nsamples(ljh) .== read(h5r["$(LJH.channel(ljh))/nsamples"]))
-    @test all( [LJH.rowcount(record) for record in ljh] .== read(h5r["$(LJH.channel(ljh))/frame1index"]) )
+    @test all( [LJH.frame1index(record) for record in ljh] .== read(h5r["$(LJH.channel(ljh))/frame1index"]) )
     close(ljh)
     close(h5r)
     rm(h5.filename)

--- a/test/basis_apply.jl
+++ b/test/basis_apply.jl
@@ -21,16 +21,16 @@ end
 
 @testset "BasisAnalyzer" begin
     FrameTime, PretrigNSamples = 9.6e-6, 100
-    r = LJH.LJHRecord{FrameTime, PretrigNSamples}(1:1000,1,2)
-    r3 = LJH.LJH3Record(1:1000,0,10,20)
+    r = LJH.LJHRecord{FrameTime, PretrigNSamples}(1:1000,10,20)
+    r3 = LJH.LJH3Record{FrameTime}(1:1000,PretrigNSamples,10,20)
     analyzer = Pope.BasisAnalyzer(rand(6,1000))
-    dataproduct = analyzer(r)
-    dataproduct3 = analyzer(r3)
-    @test dataproduct.reduced == dataproduct3.reduced
-    @test dataproduct.residual_std == dataproduct3.residual_std
-    @test dataproduct.timestamp_usec == LJH.timestamp_usec(r)
-    @test dataproduct.first_rising_sample == 0
-    @test dataproduct.nsamples == length(r)
+    dp = analyzer(r)
+    dp3 = analyzer(r3)
+    @test dp.reduced == dp3.reduced
+    @test dp.residual_std == dp3.residual_std
+    @test dp.timestamp_usec == dp3.timestamp_usec == LJH.timestamp_usec(r)
+    @test dp.first_rising_sample == dp.first_rising_sample == PretrigNSamples
+    @test dp.nsamples == dp3.nsamples == length(r)
 end
 
 @testset "BasisBufferedWriter" begin

--- a/test/basis_apply.jl
+++ b/test/basis_apply.jl
@@ -20,7 +20,8 @@ using ReferenceMicrocalFiles
 end
 
 @testset "BasisAnalyzer" begin
-    r = LJH.LJHRecord(1:1000,1,2)
+    FrameTime, PretrigNSamples = 9.6e-6, 100
+    r = LJH.LJHRecord{FrameTime, PretrigNSamples}(1:1000,1,2)
     r3 = LJH.LJH3Record(1:1000,0,10,20)
     analyzer = Pope.BasisAnalyzer(rand(6,1000))
     dataproduct = analyzer(r)

--- a/test/ljh.jl
+++ b/test/ljh.jl
@@ -9,12 +9,12 @@ timestamps = [Int64(round(r*(dt/nrow)*1e6)) for r in rowcounts]
 data = rand(UInt16, nsamp,N)
 
 fname22 = "artifacts/ljh22_chan1.ljh"
-ljh22=LJH.create(fname22, dt, npre, nsamp, version="2.2.0", number_of_rows=nrow)
+ljh22=LJH.create(fname22, dt, npre, nsamp, version="2.2.0", num_rows=nrow)
 write(ljh22, data, rowcounts, timestamps)
 close(ljh22)
 
 fname21 = "artifacts/ljh21_chan1.ljh"
-ljh21=LJH.create(fname21, dt, npre, nsamp, version="2.1.0", number_of_rows=nrow)
+ljh21=LJH.create(fname21, dt, npre, nsamp, version="2.1.0", num_rows=nrow)
 write(ljh21, data, rowcounts)
 close(ljh21)
 

--- a/test/ljh.jl
+++ b/test/ljh.jl
@@ -1,98 +1,89 @@
 using Base.Test
 using Pope: LJH
 
-# Write file 1 as an LJH 2.1 file and files 2 as LJH 2.2 with identical data.
-name21, f1 = mktemp()
-name22, f2 = mktemp()
 
-dt = 9.6e-6
-npre = 200
-nsamp = 1000
-nrow = 30
+dt = 9.6e-6; npre = 200; nsamp = 1000; nrow = 30
+rowcounts = collect(5001:1000:10001)
+N=length(rowcounts)
+timestamps = [Int64(round(r*(dt/nrow)*1e6)) for r in rowcounts]
+data = rand(UInt16, nsamp,N)
 
-LJH.writeljhheader(f1, dt, npre, nsamp; version="2.1.0", number_of_rows=nrow)
-LJH.writeljhheader(f2, dt, npre, nsamp; version="2.2.0", number_of_rows=nrow)
+fname22 = "artifacts/ljh22_chan1.ljh"
+ljh22=LJH.create(fname22, dt, npre, nsamp, version="2.2.0", number_of_rows=nrow)
+write(ljh22, data, rowcounts, timestamps)
+close(ljh22)
 
-rowcount = collect(5000:1000:10000)
-timestamps = [Int64(round(r*(dt/30)*1e6)) for r in rowcount]
-N = length(rowcount)
+fname21 = "artifacts/ljh21_chan1.ljh"
+ljh21=LJH.create(fname21, dt, npre, nsamp, version="2.1.0", number_of_rows=nrow)
+write(ljh21, data, rowcounts)
+close(ljh21)
 
-data = rand(UInt16, nsamp, N)
-data[1,:] = 0xffff
+@testset "LJHGroup for single file access" begin
+    for ljh in [LJHGroup(fname21), LJHGroup(fname22)]
+        @test LJH.record_nsamples(ljh) == nsamp
+        @test LJH.pretrig_nsamples(ljh) == npre
+        @test LJH.frametime(ljh) == dt
+        @test LJH.length(ljh) == N
 
-ljh_f1 = LJH.LJHFile(name21,seekstart(f1))
-ljh_f2 = LJH.LJHFile(name22,seekstart(f2))
-
-write(ljh_f1, data, rowcount)
-write(ljh_f2, data, rowcount, timestamps)
-
-close(f1)
-close(f2)
-# Now check that the data are readable
-ljh21 = LJHGroup(name21)
-ljh22 = LJHGroup(name22)
-
-@testset "ljh" begin
-
-# Test that the header info is correct
-for ljh in (ljh21, ljh22)
-    @test LJH.record_nsamples(ljh) == nsamp
-    @test LJH.pretrig_nsamples(ljh) == npre
-    @test LJH.frametime(ljh) == dt
-    @test LJH.length(ljh) == N
-
-    # Test indexed access
-    ranges = (1:N, N:-1:1, 1:3:N, N:-2:1)
-    for r in ranges
-        for i = r
+        for i = 1:length(ljh)
             record = ljh[i]
-            @test record.data==data[:,i]
-            @test record.timestamp_usec==timestamps[i]
+            @test LJH.data(record)==data[:,i]
+            @test LJH.timestamp_usec(record)==timestamps[i] # LJH22 files calculate a timestamp from the rowcount
+            if LJH.filenames(ljh)[1] == fname22
+                @test LJH.rowcount(record)==rowcounts[i]
+            else
+                # the rowcount in an LJH21 file is only expected to be accurate to 4 us
+                @test abs(LJH.rowcount(record)-rowcounts[i])<=20
+            end
+        end
+        LJH.row(ljh)
+        LJH.column(ljh)
+        LJH.num_rows(ljh)
+        LJH.num_columns(ljh)
+
+        # test slices
+        for (r1,r2) in zip(collect(ljh[2:4]), collect(ljh)[2:4])
+            @test r1.data==r2.data
         end
     end
-    LJH.row(ljh)
-    LJH.column(ljh)
-    LJH.num_rows(ljh)
-    LJH.num_columns(ljh)
+end
 
-    # test slices
-    for (r1,r2) in zip(collect(ljh[2:4]), collect(ljh)[2:4])
-        @test r1.data==r2.data
+@testset "LJHGroup of 3 files" begin
+    grp = LJHGroup([fname22, fname22, fname22])
+    for j=1:3N
+        record = grp[j]
+        d,r,t = LJH.data(record), LJH.rowcount(record), LJH.timestamp_usec(record)
+        i = mod(j-1, N)+1
+        @test d == data[:,i]
+        @test t == timestamps[i]
+        @test r == rowcounts[i]
+    end
+    for (r1,r2) in zip(collect(grp[3:10]), collect(grp)[3:10])
+        @test LJH.data(r1) == LJH.data(r2)
+        @test LJH.rowcount(r1) == LJH.rowcount(r2)
+        @test LJH.timestamp_usec(r1) == LJH.timestamp_usec(r2)
+    end
+    @test LJH.lengths(grp) == [N,N,N]
+
+    grp.ljhfiles[1].record_nsamples=0
+    @test_throws AssertionError LJH.record_nsamples(grp)
+end
+
+@testset "LJH single file API" begin
+    for ljh in [LJHFile(fname21), LJHFile(fname22)]
+        data_r, rowcount_r, timestamp_usec_r = LJH.get_data_rowcount_timestamp(ljh)
+        @test data_r == data
+        if LJH.filename(ljh) == fname22
+            @test rowcount_r == rowcounts
+        else
+            # the rowcount in an LJH21 file is only expected to be accurate to 4 us
+            @test maximum(abs.(rowcount_r-rowcounts)) <= 20
+        end
+        @test timestamp_usec_r == timestamps
+
+        LJH.seekto(ljh,N)
+        record = get(LJH.tryread(ljh))
+        @test isnull(LJH.tryread(ljh))
+        @test record == ljh[end]
     end
 end
-
-# Now a group corresponding to 3 files (actually, same one 3 times)
-grp = LJHGroup([name22, name21, name22])
-for j=1:3N
-    record = grp[j]
-    d,r,t = record.data, record.rowcount, record.timestamp_usec
-    i = mod(j-1, N)+1
-    @test d==data[:,i]
-    @test t==timestamps[i]
-end
-
-
-for (r1,r2) in zip(collect(grp[3:10]), collect(grp)[3:10])
-    @test r1.data == r2.data
-    @test r1.rowcount == r2.rowcount
-    @test r1.timestamp_usec == r2.timestamp_usec
-end
-@test LJH.lengths(grp) == [N,N,N]
-
-grp.ljhfiles[1].record_nsamples=0
-@test_throws AssertionError LJH.record_nsamples(grp)
-
-data_r, rowcount_r, timestamp_usec_r = LJH.get_data_rowcount_timestamp(ljh22)
-@test data==data_r
-@test rowcount_r==rowcount
-@test timestamp_usec_r == timestamps
-
-# test tryread
-ljh = LJH.LJHFile(name22)
-LJH.seekto(ljh,1)
-data = get(LJH.tryread(ljh))
-data2 = ljh[1]
-while !isnull(LJH.tryread(ljh)) end
-close(ljh)
-@test data==data2
-end #testset ljh

--- a/test/ljh3.jl
+++ b/test/ljh3.jl
@@ -47,8 +47,9 @@ rm(fname)
 end
 
 @testset "LJH3Record and LJHRecord joint API" begin
-    FrameTime, PretrigNSamples = 9.6e-6, 100
-    r = LJH.LJHRecord{FrameTime, PretrigNSamples}(1:1000,10,20)
+    FrameTime, PretrigNSamples, NRow, row = 9.6e-6, 100, 30, 1
+    # rowcount of LJH2 files = framecount*NRow+row, framecount=frame1index
+    r = LJH.LJHRecord{FrameTime, PretrigNSamples, NRow}(1:1000,10*NRow+row,20)
     r3 = LJH.LJH3Record{FrameTime}(1:1000,PretrigNSamples,10,20)
     @test LJH.data(r) == LJH.data(r3)
     @test LJH.frameperiod(r) == LJH.frameperiod(r3)

--- a/test/ljh3.jl
+++ b/test/ljh3.jl
@@ -56,6 +56,7 @@ end
     @test LJH.first_rising_sample(r) == LJH.first_rising_sample(r3)
     @test LJH.frame1index(r) == LJH.frame1index(r3)
     @test LJH.timestamp_usec(r) == LJH.timestamp_usec(r3)
+    @test length(r) == length(r3)
 end
 
 # using BenchmarkTools

--- a/test/ljh3.jl
+++ b/test/ljh3.jl
@@ -46,7 +46,16 @@ close(f2)
 rm(fname)
 end
 
-
+@testset "LJH3Record and LJHRecord joint API" begin
+    FrameTime, PretrigNSamples = 9.6e-6, 100
+    r = LJH.LJHRecord{FrameTime, PretrigNSamples}(1:1000,10,20)
+    r3 = LJH.LJH3Record{FrameTime}(1:1000,PretrigNSamples,10,20)
+    @test LJH.data(r) == LJH.data(r3)
+    @test LJH.frameperiod(r) == LJH.frameperiod(r3)
+    @test LJH.first_rising_sample(r) == LJH.first_rising_sample(r3)
+    @test LJH.frame1index(r) == LJH.frame1index(r3)
+    @test LJH.timestamp_usec(r) == LJH.timestamp_usec(r3)
+end
 
 # using BenchmarkTools
 # @benchmark read(seekstart(f.io)) setup=(f=LJH3File(fname)) teardown=close(f) evals=1

--- a/test/pope.jl
+++ b/test/pope.jl
@@ -30,18 +30,18 @@ end
 @testset "single reader with DataWriter" begin
   #fname22 points to an LJH file after the ljh tests are run
   ljh = LJH.LJHFile(fname22)
-  filter=zeros(ljh.record_nsamples-1) # single lag filter
-  filter_at=zeros(ljh.record_nsamples-1) # single lag filter arrival time component
-  npresamples=ljh.pretrig_nsamples # number of sample trigger
-  nsamples=ljh.record_nsamples # length of pulse in sample
-  average_pulse_peak_index=ljh.pretrig_nsamples+30 # peak index of average pulse, look for postpeak_deriv after this
+  filter=zeros(LJH.record_nsamples(ljh)-1) # single lag filter
+  filter_at=zeros(LJH.record_nsamples(ljh)-1) # single lag filter arrival time component
+  npresamples=LJH.pretrig_nsamples(ljh) # number of sample trigger
+  nsamples=LJH.record_nsamples(ljh) # length of pulse in sample
+  average_pulse_peak_index=LJH.pretrig_nsamples(ljh)+30 # peak index of average pulse, look for postpeak_deriv after this
   shift_threshold = 5
-  analyzer = Pope.MassCompatibleAnalysisFeb2017(filter, filter_at, npresamples, nsamples, average_pulse_peak_index, ljh.frametime, shift_threshold,[0.0,0.0],[0.0,0.0],"manually made in runtests.jl")
+  analyzer = Pope.MassCompatibleAnalysisFeb2017(filter, filter_at, npresamples, nsamples, average_pulse_peak_index, LJH.frametime(ljh), shift_threshold,[0.0,0.0],[0.0,0.0],"manually made in runtests.jl")
   output_fname = tempname()
   output_f = open(output_fname,"w")
   @show stat(output_f)
   product_writer = Pope.DataWriter(output_f)
-  reader = Pope.make_reader(ljh.filename, analyzer, product_writer)
+  reader = Pope.make_reader(LJH.filename(ljh), analyzer, product_writer)
   readers = push!(Pope.Readers(),reader)
   schedule(readers)
   Pope.stop(readers)

--- a/test/pope.jl
+++ b/test/pope.jl
@@ -28,8 +28,8 @@ let
 end
 
 @testset "single reader with DataWriter" begin
-  #name22 points to an LJH file after the ljh tests are run
-  ljh = LJH.LJHFile(name22)
+  #fname22 points to an LJH file after the ljh tests are run
+  ljh = LJH.LJHFile(fname22)
   filter=zeros(ljh.record_nsamples-1) # single lag filter
   filter_at=zeros(ljh.record_nsamples-1) # single lag filter arrival time component
   npresamples=ljh.pretrig_nsamples # number of sample trigger


### PR DESCRIPTION
Add a shared API between `LJHRecord` and `LJH3Record`. This combined with `ljhopen` forms the basis of a shared API between LJH2 and LJH3 files. 

Really the LJH docs should be re-written to show only this API.

fixes #3, fixes #4 