### PR TITLE
install scripts to ~/.pope add headers to julia scripts based on http…

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,4 +1,4 @@
-# copy scripts to ~/.pope
+# symlink scripts so we can call via ~/.pope/debugscript.jl
 println("running Pope/build.jl")
 scriptsdir = normpath(joinpath(@__DIR__, "..", "scripts"))
 targetdir = expanduser("~/.pope")
@@ -10,12 +10,15 @@ end
 @show targetdir
 for n in readdir(scriptsdir)
     p = joinpath(scriptsdir, n)
+    t = joinpath(targetdir, n)
     if isfile(p)
-        s = "copying $(basename(n)) to $targetdir"
-        if isfile(p)
+        s = "linking $p $t"
+        if isfile(t)
             s*=" (overwriting)"
+            @show t
+            rm(t)
         end
         println(s)
-        cp(p, joinpath(targetdir,n), force=true)
+        symlink(p, t)
     end
 end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,0 +1,21 @@
+# copy scripts to ~/.pope
+println("running Pope/build.jl")
+scriptsdir = normpath(joinpath(@__DIR__, "..", "scripts"))
+targetdir = expanduser("~/.pope")
+if !isdir(targetdir)
+    println("creating $targetdir")
+    mkdir(targetdir)
+end
+@show scriptsdir
+@show targetdir
+for n in readdir(scriptsdir)
+    p = joinpath(scriptsdir, n)
+    if isfile(p)
+        s = "copying $(basename(n)) to $targetdir"
+        if isfile(p)
+            s*=" (overwriting)"
+        end
+        println(s)
+        cp(p, joinpath(targetdir,n), force=true)
+    end
+end

--- a/scripts/basis_create.jl
+++ b/scripts/basis_create.jl
@@ -1,4 +1,11 @@
-#!/usr/bin/env julia
+#!/bin/bash
+#=
+JULIA="${JULIA:-julia}"
+JULIA_CMD="${JULIA_CMD:-$JULIA --color=yes --startup-file=no}"
+export JULIA_PROJECT="Pope"
+export JULIA_LOAD_PATH=@:@stdlib  # exclude default environment
+exec $JULIA_CMD -e 'include(popfirst!(ARGS))' "${BASH_SOURCE[0]}" "$@"
+=#
 
 using ArgParse
 s = ArgParseSettings()

--- a/scripts/basis_create.jl
+++ b/scripts/basis_create.jl
@@ -1,5 +1,20 @@
-#!/usr/bin/env julia --project --color=yes --startup-file=no
-
+#!/bin/bash
+#=
+JULIA="${JULIA:-julia}"
+JULIA_CMD="${JULIA_CMD:-$JULIA --color=yes --startup-file=no}"
+# below gets the directory name of the script, even if there is a symlink involved
+# from https://stackoverflow.com/questions/59895/get-the-source-directory-of-a-bash-script-from-within-the-script-itself
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+export JULIA_PROJECT=$DIR/..
+export JULIA_LOAD_PATH=@:@stdlib  # exclude default environment
+exec $JULIA_CMD -e 'include(popfirst!(ARGS))' "${BASH_SOURCE[0]}" "$@"
+=#
 using ArgParse
 s = ArgParseSettings()
 @add_arg_table s begin

--- a/scripts/basis_create.jl
+++ b/scripts/basis_create.jl
@@ -1,11 +1,4 @@
-#!/bin/bash
-#=
-JULIA="${JULIA:-julia}"
-JULIA_CMD="${JULIA_CMD:-$JULIA --color=yes --startup-file=no}"
-export JULIA_PROJECT="$(pwd)/$JULIA_PROJECT.."
-export JULIA_LOAD_PATH=@:@stdlib  # exclude default environment
-exec $JULIA_CMD -e 'include(popfirst!(ARGS))' "${BASH_SOURCE[0]}" "$@"
-=#
+#!/usr/bin/env julia --project --color=yes --startup-file=no
 
 using ArgParse
 s = ArgParseSettings()

--- a/scripts/basis_create.jl
+++ b/scripts/basis_create.jl
@@ -1,4 +1,11 @@
-#!/usr/bin/env julia --project --color=yes --startup-file=no
+#!/bin/bash
+#=
+JULIA="${JULIA:-julia}"
+JULIA_CMD="${JULIA_CMD:-$JULIA --color=yes --startup-file=no}"
+export JULIA_PROJECT="$(pwd)/$JULIA_PROJECT.."
+export JULIA_LOAD_PATH=@:@stdlib  # exclude default environment
+exec $JULIA_CMD -e 'include(popfirst!(ARGS))' "${BASH_SOURCE[0]}" "$@"
+=#
 
 using ArgParse
 s = ArgParseSettings()

--- a/scripts/basis_create.jl
+++ b/scripts/basis_create.jl
@@ -2,7 +2,7 @@
 #=
 JULIA="${JULIA:-julia}"
 JULIA_CMD="${JULIA_CMD:-$JULIA --color=yes --startup-file=no}"
-export JULIA_PROJECT="Pope"
+export JULIA_PROJECT="$(pwd)/$JULIA_PROJECT.."
 export JULIA_LOAD_PATH=@:@stdlib  # exclude default environment
 exec $JULIA_CMD -e 'include(popfirst!(ARGS))' "${BASH_SOURCE[0]}" "$@"
 =#

--- a/scripts/basis_plots.jl
+++ b/scripts/basis_plots.jl
@@ -1,4 +1,11 @@
-#!/usr/bin/env julia
+#!/bin/bash
+#=
+JULIA="${JULIA:-julia}"
+JULIA_CMD="${JULIA_CMD:-$JULIA --color=yes --startup-file=no}"
+export JULIA_PROJECT="Pope"
+export JULIA_LOAD_PATH=@:@stdlib  # exclude default environment
+exec $JULIA_CMD -e 'include(popfirst!(ARGS))' "${BASH_SOURCE[0]}" "$@"
+=#
 
 using ArgParse
 s = ArgParseSettings()

--- a/scripts/basis_plots.jl
+++ b/scripts/basis_plots.jl
@@ -1,5 +1,20 @@
-#!/usr/bin/env julia --project --color=yes --startup-file=no
-
+#!/bin/bash
+#=
+JULIA="${JULIA:-julia}"
+JULIA_CMD="${JULIA_CMD:-$JULIA --color=yes --startup-file=no}"
+# below gets the directory name of the script, even if there is a symlink involved
+# from https://stackoverflow.com/questions/59895/get-the-source-directory-of-a-bash-script-from-within-the-script-itself
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+export JULIA_PROJECT=$DIR/..
+export JULIA_LOAD_PATH=@:@stdlib  # exclude default environment
+exec $JULIA_CMD -e 'include(popfirst!(ARGS))' "${BASH_SOURCE[0]}" "$@"
+=#
 using ArgParse
 s = ArgParseSettings()
 @add_arg_table s begin

--- a/scripts/basis_plots.jl
+++ b/scripts/basis_plots.jl
@@ -1,11 +1,4 @@
-#!/bin/bash
-#=
-JULIA="${JULIA:-julia}"
-JULIA_CMD="${JULIA_CMD:-$JULIA --color=yes --startup-file=no}"
-export JULIA_PROJECT="$(pwd)/$JULIA_PROJECT.."
-export JULIA_LOAD_PATH=@:@stdlib  # exclude default environment
-exec $JULIA_CMD -e 'include(popfirst!(ARGS))' "${BASH_SOURCE[0]}" "$@"
-=#
+#!/usr/bin/env julia --project --color=yes --startup-file=no
 
 using ArgParse
 s = ArgParseSettings()

--- a/scripts/basis_plots.jl
+++ b/scripts/basis_plots.jl
@@ -1,4 +1,11 @@
-#!/usr/bin/env julia --project --color=yes --startup-file=no
+#!/bin/bash
+#=
+JULIA="${JULIA:-julia}"
+JULIA_CMD="${JULIA_CMD:-$JULIA --color=yes --startup-file=no}"
+export JULIA_PROJECT="$(pwd)/$JULIA_PROJECT.."
+export JULIA_LOAD_PATH=@:@stdlib  # exclude default environment
+exec $JULIA_CMD -e 'include(popfirst!(ARGS))' "${BASH_SOURCE[0]}" "$@"
+=#
 
 using ArgParse
 s = ArgParseSettings()

--- a/scripts/basis_plots.jl
+++ b/scripts/basis_plots.jl
@@ -2,7 +2,7 @@
 #=
 JULIA="${JULIA:-julia}"
 JULIA_CMD="${JULIA_CMD:-$JULIA --color=yes --startup-file=no}"
-export JULIA_PROJECT="Pope"
+export JULIA_PROJECT="$(pwd)/$JULIA_PROJECT.."
 export JULIA_LOAD_PATH=@:@stdlib  # exclude default environment
 exec $JULIA_CMD -e 'include(popfirst!(ARGS))' "${BASH_SOURCE[0]}" "$@"
 =#

--- a/scripts/debugscript.jl
+++ b/scripts/debugscript.jl
@@ -1,14 +1,9 @@
-#!/bin/bash
-#=
-JULIA="${JULIA:-julia}"
-JULIA_CMD="${JULIA_CMD:-$JULIA --color=yes --startup-file=no}"
-export JULIA_PROJECT="$(pwd)/$JULIA_PROJECT.."
-export JULIA_LOAD_PATH=@:@stdlib  # exclude default environment
-exec $JULIA_CMD -e 'include(popfirst!(ARGS))' "${BASH_SOURCE[0]}" "$@"
-=#
-@show ENV["JULIA_PROJECT"]
-@show ENV["JULIA_LOAD_PATH"]
+#!/usr/bin/env julia --project --color=yes --startup-file=no
+
+tstart = time()
+println("before using ArgParse ", time()-tstart)
 using ArgParse
+println("after using ArgParse ",time()-tstart)
 s = ArgParseSettings()
 @add_arg_table s begin
     "--outputfile", "-o"
@@ -16,7 +11,8 @@ s = ArgParseSettings()
         help="specify the path of the outputfile, otherwise it will make one up based on pulse_file"
 
 end
+println("after add_arg_table ",time()-tstart)
 parsed_args = parse_args(ARGS, s)
-println(parsed_args)
+@show parsed_args
 using Pope
-println("your other scripts should work!")
+println("your other scripts should work! ",time()-tstart)

--- a/scripts/debugscript.jl
+++ b/scripts/debugscript.jl
@@ -1,0 +1,22 @@
+#!/bin/bash
+#=
+JULIA="${JULIA:-julia}"
+JULIA_CMD="${JULIA_CMD:-$JULIA --color=yes --startup-file=no}"
+export JULIA_PROJECT="$(pwd)/$JULIA_PROJECT.."
+export JULIA_LOAD_PATH=@:@stdlib  # exclude default environment
+exec $JULIA_CMD -e 'include(popfirst!(ARGS))' "${BASH_SOURCE[0]}" "$@"
+=#
+@show ENV["JULIA_PROJECT"]
+@show ENV["JULIA_LOAD_PATH"]
+using ArgParse
+s = ArgParseSettings()
+@add_arg_table s begin
+    "--outputfile", "-o"
+        arg_type = String
+        help="specify the path of the outputfile, otherwise it will make one up based on pulse_file"
+
+end
+parsed_args = parse_args(ARGS, s)
+println(parsed_args)
+using Pope
+println("your other scripts should work!")

--- a/scripts/debugscript.jl
+++ b/scripts/debugscript.jl
@@ -1,9 +1,14 @@
-#!/usr/bin/env julia --project --color=yes --startup-file=no
-
-tstart = time()
-println("before using ArgParse ", time()-tstart)
+#!/bin/bash
+#=
+JULIA="${JULIA:-julia}"
+JULIA_CMD="${JULIA_CMD:-$JULIA --color=yes --startup-file=no}"
+export JULIA_PROJECT="$(pwd)/$JULIA_PROJECT.."
+export JULIA_LOAD_PATH=@:@stdlib  # exclude default environment
+exec $JULIA_CMD -e 'include(popfirst!(ARGS))' "${BASH_SOURCE[0]}" "$@"
+=#
+@show ENV["JULIA_PROJECT"]
+@show ENV["JULIA_LOAD_PATH"]
 using ArgParse
-println("after using ArgParse ",time()-tstart)
 s = ArgParseSettings()
 @add_arg_table s begin
     "--outputfile", "-o"
@@ -11,8 +16,7 @@ s = ArgParseSettings()
         help="specify the path of the outputfile, otherwise it will make one up based on pulse_file"
 
 end
-println("after add_arg_table ",time()-tstart)
 parsed_args = parse_args(ARGS, s)
-@show parsed_args
+println(parsed_args)
 using Pope
-println("your other scripts should work! ",time()-tstart)
+println("your other scripts should work!")

--- a/scripts/debugscript.jl
+++ b/scripts/debugscript.jl
@@ -1,6 +1,23 @@
-#!/usr/bin/env julia --project --color=yes --startup-file=no
-
+#!/bin/bash
+#=
+JULIA="${JULIA:-julia}"
+JULIA_CMD="${JULIA_CMD:-$JULIA --color=yes --startup-file=no}"
+# below gets the directory name of the script, even if there is a symlink involved
+# from https://stackoverflow.com/questions/59895/get-the-source-directory-of-a-bash-script-from-within-the-script-itself
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+export JULIA_PROJECT=$DIR/..
+export JULIA_LOAD_PATH=@:@stdlib  # exclude default environment
+exec $JULIA_CMD -e 'include(popfirst!(ARGS))' "${BASH_SOURCE[0]}" "$@"
+=#
 tstart = time()
+@show get(ENV,"JULIA_PROJECT", nothing)
+@show get(ENV,"JULIA_LOAD_PATH", nothing)
 println("before using ArgParse ", time()-tstart)
 using ArgParse
 println("after using ArgParse ",time()-tstart)

--- a/scripts/ljh2off.jl
+++ b/scripts/ljh2off.jl
@@ -1,4 +1,11 @@
-#!/usr/bin/env julia --project --color=yes --startup-file=no
+#!/bin/bash
+#=
+JULIA="${JULIA:-julia}"
+JULIA_CMD="${JULIA_CMD:-$JULIA --color=yes --startup-file=no}"
+export JULIA_PROJECT="$(pwd)/$JULIA_PROJECT.."
+export JULIA_LOAD_PATH=@:@stdlib  # exclude default environment
+exec $JULIA_CMD -e 'include(popfirst!(ARGS))' "${BASH_SOURCE[0]}" "$@"
+=#
 
 using ArgParse
 s = ArgParseSettings(description="Coallate ljh files and convert to off with given model file\n"*

--- a/scripts/ljh2off.jl
+++ b/scripts/ljh2off.jl
@@ -1,11 +1,4 @@
-#!/bin/bash
-#=
-JULIA="${JULIA:-julia}"
-JULIA_CMD="${JULIA_CMD:-$JULIA --color=yes --startup-file=no}"
-export JULIA_PROJECT="$(pwd)/$JULIA_PROJECT.."
-export JULIA_LOAD_PATH=@:@stdlib  # exclude default environment
-exec $JULIA_CMD -e 'include(popfirst!(ARGS))' "${BASH_SOURCE[0]}" "$@"
-=#
+#!/usr/bin/env julia --project --color=yes --startup-file=no
 
 using ArgParse
 s = ArgParseSettings(description="Coallate ljh files and convert to off with given model file\n"*

--- a/scripts/ljh2off.jl
+++ b/scripts/ljh2off.jl
@@ -2,7 +2,7 @@
 #=
 JULIA="${JULIA:-julia}"
 JULIA_CMD="${JULIA_CMD:-$JULIA --color=yes --startup-file=no}"
-export JULIA_PROJECT="Pope"
+export JULIA_PROJECT="$(pwd)/$JULIA_PROJECT.."
 export JULIA_LOAD_PATH=@:@stdlib  # exclude default environment
 exec $JULIA_CMD -e 'include(popfirst!(ARGS))' "${BASH_SOURCE[0]}" "$@"
 =#

--- a/scripts/ljh2off.jl
+++ b/scripts/ljh2off.jl
@@ -1,5 +1,20 @@
-#!/usr/bin/env julia --project --color=yes --startup-file=no
-
+#!/bin/bash
+#=
+JULIA="${JULIA:-julia}"
+JULIA_CMD="${JULIA_CMD:-$JULIA --color=yes --startup-file=no}"
+# below gets the directory name of the script, even if there is a symlink involved
+# from https://stackoverflow.com/questions/59895/get-the-source-directory-of-a-bash-script-from-within-the-script-itself
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+export JULIA_PROJECT=$DIR/..
+export JULIA_LOAD_PATH=@:@stdlib  # exclude default environment
+exec $JULIA_CMD -e 'include(popfirst!(ARGS))' "${BASH_SOURCE[0]}" "$@"
+=#
 using ArgParse
 s = ArgParseSettings(description="Coallate ljh files and convert to off with given model file\n"*
 "example usage:\n"*

--- a/scripts/ljh2off.jl
+++ b/scripts/ljh2off.jl
@@ -1,4 +1,11 @@
-#!/usr/bin/env julia
+#!/bin/bash
+#=
+JULIA="${JULIA:-julia}"
+JULIA_CMD="${JULIA_CMD:-$JULIA --color=yes --startup-file=no}"
+export JULIA_PROJECT="Pope"
+export JULIA_LOAD_PATH=@:@stdlib  # exclude default environment
+exec $JULIA_CMD -e 'include(popfirst!(ARGS))' "${BASH_SOURCE[0]}" "$@"
+=#
 
 using ArgParse
 s = ArgParseSettings(description="Coallate ljh files and convert to off with given model file\n"*

--- a/scripts/noise_analysis.jl
+++ b/scripts/noise_analysis.jl
@@ -1,11 +1,4 @@
-#!/bin/bash
-#=
-JULIA="${JULIA:-julia}"
-JULIA_CMD="${JULIA_CMD:-$JULIA --color=yes --startup-file=no}"
-export JULIA_PROJECT="$(pwd)/$JULIA_PROJECT.."
-export JULIA_LOAD_PATH=@:@stdlib  # exclude default environment
-exec $JULIA_CMD -e 'include(popfirst!(ARGS))' "${BASH_SOURCE[0]}" "$@"
-=#
+#!/usr/bin/env julia --project --color=yes --startup-file=no
 
 # Parse command-line first, so a failure can be detected before the compilation
 # or execution of any code unrelated to argument parsing.

--- a/scripts/noise_analysis.jl
+++ b/scripts/noise_analysis.jl
@@ -1,4 +1,11 @@
-#!/usr/bin/env julia --project --color=yes --startup-file=no
+#!/bin/bash
+#=
+JULIA="${JULIA:-julia}"
+JULIA_CMD="${JULIA_CMD:-$JULIA --color=yes --startup-file=no}"
+export JULIA_PROJECT="$(pwd)/$JULIA_PROJECT.."
+export JULIA_LOAD_PATH=@:@stdlib  # exclude default environment
+exec $JULIA_CMD -e 'include(popfirst!(ARGS))' "${BASH_SOURCE[0]}" "$@"
+=#
 
 # Parse command-line first, so a failure can be detected before the compilation
 # or execution of any code unrelated to argument parsing.

--- a/scripts/noise_analysis.jl
+++ b/scripts/noise_analysis.jl
@@ -2,7 +2,7 @@
 #=
 JULIA="${JULIA:-julia}"
 JULIA_CMD="${JULIA_CMD:-$JULIA --color=yes --startup-file=no}"
-export JULIA_PROJECT="Pope"
+export JULIA_PROJECT="$(pwd)/$JULIA_PROJECT.."
 export JULIA_LOAD_PATH=@:@stdlib  # exclude default environment
 exec $JULIA_CMD -e 'include(popfirst!(ARGS))' "${BASH_SOURCE[0]}" "$@"
 =#

--- a/scripts/noise_analysis.jl
+++ b/scripts/noise_analysis.jl
@@ -1,4 +1,11 @@
-#!/usr/bin/env julia
+#!/bin/bash
+#=
+JULIA="${JULIA:-julia}"
+JULIA_CMD="${JULIA_CMD:-$JULIA --color=yes --startup-file=no}"
+export JULIA_PROJECT="Pope"
+export JULIA_LOAD_PATH=@:@stdlib  # exclude default environment
+exec $JULIA_CMD -e 'include(popfirst!(ARGS))' "${BASH_SOURCE[0]}" "$@"
+=#
 
 # Parse command-line first, so a failure can be detected before the compilation
 # or execution of any code unrelated to argument parsing.

--- a/scripts/noise_analysis.jl
+++ b/scripts/noise_analysis.jl
@@ -1,5 +1,20 @@
-#!/usr/bin/env julia --project --color=yes --startup-file=no
-
+#!/bin/bash
+#=
+JULIA="${JULIA:-julia}"
+JULIA_CMD="${JULIA_CMD:-$JULIA --color=yes --startup-file=no}"
+# below gets the directory name of the script, even if there is a symlink involved
+# from https://stackoverflow.com/questions/59895/get-the-source-directory-of-a-bash-script-from-within-the-script-itself
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+export JULIA_PROJECT=$DIR/..
+export JULIA_LOAD_PATH=@:@stdlib  # exclude default environment
+exec $JULIA_CMD -e 'include(popfirst!(ARGS))' "${BASH_SOURCE[0]}" "$@"
+=#
 # Parse command-line first, so a failure can be detected before the compilation
 # or execution of any code unrelated to argument parsing.
 using ArgParse

--- a/scripts/noise_plots.jl
+++ b/scripts/noise_plots.jl
@@ -1,4 +1,12 @@
-#!/usr/bin/env julia
+#!/bin/bash
+#=
+JULIA="${JULIA:-julia}"
+JULIA_CMD="${JULIA_CMD:-$JULIA --color=yes --startup-file=no}"
+export JULIA_PROJECT="Pope"
+export JULIA_LOAD_PATH=@:@stdlib  # exclude default environment
+exec $JULIA_CMD -e 'include(popfirst!(ARGS))' "${BASH_SOURCE[0]}" "$@"
+=#
+
 
 using ArgParse
 using ARMA

--- a/scripts/noise_plots.jl
+++ b/scripts/noise_plots.jl
@@ -1,5 +1,20 @@
-#!/usr/bin/env julia --project --color=yes --startup-file=no
-
+#!/bin/bash
+#=
+JULIA="${JULIA:-julia}"
+JULIA_CMD="${JULIA_CMD:-$JULIA --color=yes --startup-file=no}"
+# below gets the directory name of the script, even if there is a symlink involved
+# from https://stackoverflow.com/questions/59895/get-the-source-directory-of-a-bash-script-from-within-the-script-itself
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+export JULIA_PROJECT=$DIR/..
+export JULIA_LOAD_PATH=@:@stdlib  # exclude default environment
+exec $JULIA_CMD -e 'include(popfirst!(ARGS))' "${BASH_SOURCE[0]}" "$@"
+=#
 using ArgParse
 using ARMA
 using HDF5

--- a/scripts/noise_plots.jl
+++ b/scripts/noise_plots.jl
@@ -2,7 +2,7 @@
 #=
 JULIA="${JULIA:-julia}"
 JULIA_CMD="${JULIA_CMD:-$JULIA --color=yes --startup-file=no}"
-export JULIA_PROJECT="Pope"
+export JULIA_PROJECT="$(pwd)/$JULIA_PROJECT.."
 export JULIA_LOAD_PATH=@:@stdlib  # exclude default environment
 exec $JULIA_CMD -e 'include(popfirst!(ARGS))' "${BASH_SOURCE[0]}" "$@"
 =#

--- a/scripts/noise_plots.jl
+++ b/scripts/noise_plots.jl
@@ -1,12 +1,4 @@
-#!/bin/bash
-#=
-JULIA="${JULIA:-julia}"
-JULIA_CMD="${JULIA_CMD:-$JULIA --color=yes --startup-file=no}"
-export JULIA_PROJECT="$(pwd)/$JULIA_PROJECT.."
-export JULIA_LOAD_PATH=@:@stdlib  # exclude default environment
-exec $JULIA_CMD -e 'include(popfirst!(ARGS))' "${BASH_SOURCE[0]}" "$@"
-=#
-
+#!/usr/bin/env julia --project --color=yes --startup-file=no
 
 using ArgParse
 using ARMA

--- a/scripts/noise_plots.jl
+++ b/scripts/noise_plots.jl
@@ -1,4 +1,12 @@
-#!/usr/bin/env julia --project --color=yes --startup-file=no
+#!/bin/bash
+#=
+JULIA="${JULIA:-julia}"
+JULIA_CMD="${JULIA_CMD:-$JULIA --color=yes --startup-file=no}"
+export JULIA_PROJECT="$(pwd)/$JULIA_PROJECT.."
+export JULIA_LOAD_PATH=@:@stdlib  # exclude default environment
+exec $JULIA_CMD -e 'include(popfirst!(ARGS))' "${BASH_SOURCE[0]}" "$@"
+=#
+
 
 using ArgParse
 using ARMA

--- a/test/basis_creation.jl
+++ b/test/basis_creation.jl
@@ -72,10 +72,11 @@ mass3_basis, mass3_basisinfo = Pope.create_basis_one_channel(data,noise_result,
     pulse_file,-1)
 
 @testset "scripts with SVDBasis" begin
-    @test success(run(`julia ../scripts/noise_analysis.jl $noisepath -o $noise_result_path`))
-    @test success(run(`julia ../scripts/basis_create.jl $ljhpath $noise_result_path -o $model_path`))
+    # invoke scripts through bash to use of env variables
+    @test success(run(`../scripts/noise_analysis.jl $noisepath -o $noise_result_path`))
+    @test success(run(`../scripts/basis_create.jl $ljhpath $noise_result_path -o $model_path`))
     if !haskey(ENV,"POPE_NOMATPLOTLIB")
-        @test success(run(`julia ../scripts/basis_plots.jl $model_path`))
-        @test success(run(`julia ../scripts/noise_plots.jl $noise_result_path`))
+        @test success(run(`../scripts/basis_plots.jl $model_path`))
+        @test success(run(`../scripts/noise_plots.jl $noise_result_path`))
     end
 end


### PR DESCRIPTION
Add a header to the scripts so they work if invoked as `./script.jl`. Also try to install them to `~/.pope` in `build.jl`. Oddly, `build.jl` doesn't seem to be running on travis, or when I run `Pkg.build("Pope")`. Do you know why that is?