### PR TITLE
Fix Toeplitz SVD

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,6 +22,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 TSVD = "9449cd9e-2762-5aa3-a617-5413e99d722e"
+ToeplitzMatrices = "c751599d-da0a-543b-9d20-d0a503d91d24"
 
 [compat]
 ARMA = "≥ 0.2.0"

--- a/scripts/basis_create.jl
+++ b/scripts/basis_create.jl
@@ -1,5 +1,7 @@
 #!/usr/bin/env julia
 
+using Pkg
+Pkg.activate(normpath(joinpath(@__DIR__, "..")))
 using ArgParse
 s = ArgParseSettings()
 @add_arg_table s begin

--- a/scripts/basis_create.jl
+++ b/scripts/basis_create.jl
@@ -1,7 +1,5 @@
-#!/usr/bin/env julia
+#!/usr/bin/env julia --project
 
-using Pkg
-Pkg.activate(normpath(joinpath(@__DIR__, "..")))
 using ArgParse
 s = ArgParseSettings()
 @add_arg_table s begin

--- a/scripts/basis_create.jl
+++ b/scripts/basis_create.jl
@@ -1,4 +1,4 @@
-#!/usr/bin/env julia --project
+#!/usr/bin/env julia --project=@.
 
 using ArgParse
 s = ArgParseSettings()

--- a/scripts/basis_create.jl
+++ b/scripts/basis_create.jl
@@ -1,4 +1,6 @@
-#!/usr/bin/env julia --project=@.
+#!/usr/bin/env julia
+using Pkg
+Pkg.activate(joinpath(@__DIR__, ".."))
 
 using ArgParse
 s = ArgParseSettings()

--- a/scripts/basis_plots.jl
+++ b/scripts/basis_plots.jl
@@ -1,4 +1,4 @@
-#!/usr/bin/env julia --project
+#!/usr/bin/env julia --project=@.
 
 using ArgParse
 s = ArgParseSettings()

--- a/scripts/basis_plots.jl
+++ b/scripts/basis_plots.jl
@@ -1,5 +1,7 @@
-#!/usr/bin/env julia --project=@.
+#!/usr/bin/env julia
 
+using Pkg
+Pkg.activate(joinpath(@__DIR__, ".."))
 using ArgParse
 s = ArgParseSettings()
 @add_arg_table s begin

--- a/scripts/basis_plots.jl
+++ b/scripts/basis_plots.jl
@@ -1,7 +1,4 @@
-#!/usr/bin/env julia
-
-import Pkg
-Pkg.activate(normpath(joinpath(@__DIR__, "..")))
+#!/usr/bin/env julia --project
 
 using ArgParse
 s = ArgParseSettings()

--- a/scripts/basis_plots.jl
+++ b/scripts/basis_plots.jl
@@ -1,5 +1,8 @@
 #!/usr/bin/env julia
 
+import Pkg
+Pkg.activate(normpath(joinpath(@__DIR__, "..")))
+
 using ArgParse
 s = ArgParseSettings()
 @add_arg_table s begin

--- a/scripts/ljh2off.jl
+++ b/scripts/ljh2off.jl
@@ -1,4 +1,4 @@
-#!/usr/bin/env julia --project
+#!/usr/bin/env julia --project=@.
 
 using ArgParse
 s = ArgParseSettings(description="Coallate ljh files and convert to off with given model file\n"*

--- a/scripts/ljh2off.jl
+++ b/scripts/ljh2off.jl
@@ -1,4 +1,6 @@
-#!/usr/bin/env julia --project=@.
+#!/usr/bin/env julia
+using Pkg
+Pkg.activate(joinpath(@__DIR__, ".."))
 
 using ArgParse
 s = ArgParseSettings(description="Coallate ljh files and convert to off with given model file\n"*

--- a/scripts/ljh2off.jl
+++ b/scripts/ljh2off.jl
@@ -1,5 +1,8 @@
 #!/usr/bin/env julia
 
+import Pkg
+Pkg.activate(normpath(joinpath(@__DIR__, "..")))
+
 using ArgParse
 s = ArgParseSettings(description="Coallate ljh files and convert to off with given model file\n"*
 "example usage:\n"*

--- a/scripts/ljh2off.jl
+++ b/scripts/ljh2off.jl
@@ -1,7 +1,4 @@
-#!/usr/bin/env julia
-
-import Pkg
-Pkg.activate(normpath(joinpath(@__DIR__, "..")))
+#!/usr/bin/env julia --project
 
 using ArgParse
 s = ArgParseSettings(description="Coallate ljh files and convert to off with given model file\n"*

--- a/scripts/noise_analysis.jl
+++ b/scripts/noise_analysis.jl
@@ -1,7 +1,4 @@
-#!/usr/bin/env julia
-
-import Pkg
-Pkg.activate(normpath(joinpath(@__DIR__, "..")))
+#!/usr/bin/env julia --project
 
 # Parse command-line first, so a failure can be detected before the compilation
 # or execution of any code unrelated to argument parsing.

--- a/scripts/noise_analysis.jl
+++ b/scripts/noise_analysis.jl
@@ -1,4 +1,4 @@
-#!/usr/bin/env julia --project
+#!/usr/bin/env julia --project=@.
 
 # Parse command-line first, so a failure can be detected before the compilation
 # or execution of any code unrelated to argument parsing.

--- a/scripts/noise_analysis.jl
+++ b/scripts/noise_analysis.jl
@@ -1,5 +1,8 @@
 #!/usr/bin/env julia
 
+import Pkg
+Pkg.activate(normpath(joinpath(@__DIR__, "..")))
+
 # Parse command-line first, so a failure can be detected before the compilation
 # or execution of any code unrelated to argument parsing.
 using ArgParse

--- a/scripts/noise_analysis.jl
+++ b/scripts/noise_analysis.jl
@@ -1,4 +1,6 @@
-#!/usr/bin/env julia --project=@.
+#!/usr/bin/env julia
+using Pkg
+Pkg.activate(joinpath(@__DIR__, ".."))
 
 # Parse command-line first, so a failure can be detected before the compilation
 # or execution of any code unrelated to argument parsing.

--- a/scripts/noise_plots.jl
+++ b/scripts/noise_plots.jl
@@ -1,4 +1,4 @@
-#!/usr/bin/env julia --project
+#!/usr/bin/env julia --project=@.
 
 using ArgParse
 using ARMA

--- a/scripts/noise_plots.jl
+++ b/scripts/noise_plots.jl
@@ -1,5 +1,8 @@
 #!/usr/bin/env julia
 
+import Pkg
+Pkg.activate(normpath(joinpath(@__DIR__, "..")))
+
 using ArgParse
 using ARMA
 using HDF5

--- a/scripts/noise_plots.jl
+++ b/scripts/noise_plots.jl
@@ -1,7 +1,4 @@
-#!/usr/bin/env julia
-
-import Pkg
-Pkg.activate(normpath(joinpath(@__DIR__, "..")))
+#!/usr/bin/env julia --project
 
 using ArgParse
 using ARMA

--- a/scripts/noise_plots.jl
+++ b/scripts/noise_plots.jl
@@ -1,4 +1,6 @@
-#!/usr/bin/env julia --project=@.
+#!/usr/bin/env julia
+using Pkg
+Pkg.activate(joinpath(@__DIR__, ".."))
 
 using ArgParse
 using ARMA

--- a/test/basis_creation.jl
+++ b/test/basis_creation.jl
@@ -72,10 +72,10 @@ mass3_basis, mass3_basisinfo = Pope.create_basis_one_channel(data,noise_result,
     pulse_file,-1)
 
 @testset "scripts with SVDBasis" begin
-    @test success(run(`../scripts/noise_analysis.jl $noisepath -o $noise_result_path`))
-    @test success(run(`../scripts/basis_create.jl $ljhpath $noise_result_path -o $model_path`))
+    @test success(run(`julia ../scripts/noise_analysis.jl $noisepath -o $noise_result_path`))
+    @test success(run(`julia ../scripts/basis_create.jl $ljhpath $noise_result_path -o $model_path`))
     if !haskey(ENV,"POPE_NOMATPLOTLIB")
-        @test success(run(`../scripts/basis_plots.jl $model_path`))
-        @test success(run(`../scripts/noise_plots.jl $noise_result_path`))
+        @test success(run(`julia ../scripts/basis_plots.jl $model_path`))
+        @test success(run(`julia ../scripts/noise_plots.jl $noise_result_path`))
     end
 end

--- a/test/basis_creation.jl
+++ b/test/basis_creation.jl
@@ -72,10 +72,10 @@ mass3_basis, mass3_basisinfo = Pope.create_basis_one_channel(data,noise_result,
     pulse_file,-1)
 
 @testset "scripts with SVDBasis" begin
-    @test success(run(`julia ../scripts/noise_analysis.jl $noisepath -o $noise_result_path`))
-    @test success(run(`julia ../scripts/basis_create.jl $ljhpath $noise_result_path -o $model_path`))
+    @test success(run(`../scripts/noise_analysis.jl $noisepath -o $noise_result_path`))
+    @test success(run(`../scripts/basis_create.jl $ljhpath $noise_result_path -o $model_path`))
     if !haskey(ENV,"POPE_NOMATPLOTLIB")
-        @test success(run(`julia ../scripts/basis_plots.jl $model_path`))
-        @test success(run(`julia ../scripts/noise_plots.jl $noise_result_path`))
+        @test success(run(`../scripts/basis_plots.jl $model_path`))
+        @test success(run(`../scripts/noise_plots.jl $noise_result_path`))
     end
 end


### PR DESCRIPTION
Fixes #25: use Mahalanobis distance when doing SVD on residuals in the new (autocorrelation vector) basis analysis.